### PR TITLE
implemented top sellers feature for home page

### DIFF
--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -63,7 +63,6 @@ const HotCollections = () => {
     fetchItems();
   }, []);
 
-
   return (
     <section id='section-collections' className='no-bottom'>
       <div className='container'>

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -56,8 +56,7 @@ const NewItems = () => {
       // fetch API
       try {
         const resp = await axios.get('https://us-central1-nft-cloud-functions.cloudfunctions.net/newItems');
-        let data = resp.data;
-        setItems(data);
+        setItems(resp.data);
         setTimeout(() => {
           setUiIsLoading(false);
         }, 500);

--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -1,39 +1,77 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
+// packages
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Skeleton from 'react-loading-skeleton';
+import axios from 'axios';
+
+const TopSellersSkeleton = () => {
+  return (
+    <ol className='author_list skeleton'>
+      {new Array(12).fill(0).map((_, index) => (
+        <li key={index}>
+          <div className='author_list_pp'>
+            <Skeleton circle />
+            <i className='fa fa-check' />
+          </div>
+          <div className='author_list_info'>
+            <Skeleton count={1} width='40%' height='18px' />
+            <Skeleton count={1} width='25%' height='14px' />
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
 
 const TopSellers = () => {
+  // states
+  const [_sellers, setSellers] = useState([]);
+  const [ui_isLoading, setUiIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchSellers = async () => {
+      // fetch API
+      try {
+        const resp = await axios.get('https://us-central1-nft-cloud-functions.cloudfunctions.net/topSellers');
+        setSellers(resp.data);
+        setTimeout(() => {
+          setUiIsLoading(false);
+        }, 500);
+      } catch (error) {
+        console.error('Error fetching top sellers: ', error);
+        setUiIsLoading(false);
+      }
+    }
+    fetchSellers();
+  }, []);
+
   return (
-    <section id="section-popular" className="pb-5">
-      <div className="container">
-        <div className="row">
-          <div className="col-lg-12">
-            <div className="text-center">
+    <section id='section-popular' className='pb-5'>
+      <div className='container'>
+        <div className='row'>
+          <div className='col-lg-12'>
+            <div className='text-center'>
               <h2>Top Sellers</h2>
-              <div className="small-border bg-color-2"></div>
+              <div className='small-border bg-color-2'></div>
             </div>
           </div>
-          <div className="col-md-12">
-            <ol className="author_list">
-              {new Array(12).fill(0).map((_, index) => (
+          <div className='col-md-12'>
+            {!ui_isLoading && _sellers ? (<ol className='author_list'>
+              {_sellers?.map((seller, index) => (
                 <li key={index}>
-                  <div className="author_list_pp">
-                    <Link to="/author">
-                      <img
-                        className="lazy pp-author"
-                        src={AuthorImage}
-                        alt=""
-                      />
-                      <i className="fa fa-check"></i>
+                  <div className='author_list_pp'>
+                    <Link to={`/author/${seller.authorId}`}>
+                      <img className='lazy pp-author' src={seller.authorImage} alt={`User ${seller.authorId}`} />
+                      <i className='fa fa-check' />
                     </Link>
                   </div>
-                  <div className="author_list_info">
-                    <Link to="/author">Monica Lucas</Link>
-                    <span>2.1 ETH</span>
+                  <div className='author_list_info'>
+                    <Link to={`/author/${seller.authorId}`}>{seller.authorName}</Link>
+                    <span>{seller.price} ETH</span>
                   </div>
                 </li>
               ))}
-            </ol>
+            </ol>) : <TopSellersSkeleton />}
           </div>
         </div>
       </div>

--- a/src/css/styles/global.css
+++ b/src/css/styles/global.css
@@ -1,23 +1,30 @@
 /************ SKELETONS ************/
 .skeleton { display:flex; }
+.skeleton br { display:none; }
 .skeleton .owl-stage-outer { width:100%; display:flex; gap:10px; }
+.skeleton .react-loading-skeleton { display:block; height:100%; }
 
 /** hot collections **/
 .skeleton .nft_coll { width:100%; }
 .skeleton .nft_wrap { height:152px; }
-.skeleton .nft_wrap .react-loading-skeleton { display:block; height:100%; border-radius:0; }
+.skeleton .nft_wrap .react-loading-skeleton { border-radius:0; }
 .skeleton .nft_coll_pp { height:60px; border-radius:50%; background:#ffffff; padding:5px; }
-.skeleton .nft_coll_pp .react-loading-skeleton { display:block; height:100%; }
-.skeleton .nft_coll_info { margin-top:-6px; }
+.skeleton .nft_coll_info { display:flex; flex-direction:column; gap:8px; }
+.skeleton .nft_coll_info > span { display:flex; align-items:center; justify-content:center; }
 
 /** new items **/
-.skeleton .nft__item { width:100%; height:90%; }
-.skeleton .author_list_pp { height:50px; border-radius:50%; background:#ffffff; padding:5px; }
-.skeleton .author_list_pp .react-loading-skeleton { display:block; height:100%; }
+.skeleton .nft__item { width:100%; }
+.skeleton .author_list_pp { height:50px; border-radius:50%; background:#ffffff; }
 .skeleton .nft__item_wrap { display:block; }
-.skeleton .nft__item_wrap .react-loading-skeleton { display:block; width:100%; height:100%; }
-.skeleton .nft__item_info { margin-top:4px; }
+.skeleton .nft__item_wrap .react-loading-skeleton { width:100%; }
+.skeleton .nft__item_info { margin-top:8px; display:flex; flex-direction:column; gap:8px; }
+.skeleton .nft__item_like { position:absolute; bottom:0; right:0; display:flex; align-items:center; }
 .skeleton .nft__item_like:hover i { color:#ddd; }
+
+/** top sellers **/
+.skeleton.author_list { display:block; }
+.skeleton.author_list .author_list_info { display:flex; flex-direction:column; gap:8px; }
+.skeleton.author_list .author_list_info span { line-height:1; }
 /********** END SKELETONS **********/
 
 /****** SCREEN SIZES ******/


### PR DESCRIPTION
**Task**
The top sellers feature is used to display the active and most popular NFT sellers in the marketplace. Users are able to engage the site more when there are other users around.

**Purpose**
Aside from just the NFT items, the home page should also show users (or specifically sellers in the marketplace). Since NFTs are created or sold by actual people, this data is probably going to be important and useful. Also, this data is necessary in letting users trust that the site is up-to-date with NFT activity.

**Action**
The API endpoint that returns top NFT item sellers was fetched with a `useEffect` when the page loads. Unlike the sections showcasing the items, this data does not need to be wrapped in a carousel. We only need the top 12 sellers so a numbered list was used to populate the data. More changes to how the skeletons are displayed were fixed too.

***Snippets of the loading and loaded states***
![image](https://github.com/user-attachments/assets/0d44a199-aacb-4fdd-80b3-bdd1da1f97f5)
![image](https://github.com/user-attachments/assets/451b4da8-1d4a-4a29-a6ec-610cc8cbb179)