### PR TITLE
implemented explore items feature on explore page

### DIFF
--- a/Getting Started.md
+++ b/Getting Started.md
@@ -1,0 +1,70 @@
+# Getting Started with Create React App
+
+This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+
+## Available Scripts
+
+In the project directory, you can run:
+
+### `npm start`
+
+Runs the app in the development mode.\
+Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+
+The page will reload when you make changes.\
+You may also see any lint errors in the console.
+
+### `npm test`
+
+Launches the test runner in the interactive watch mode.\
+See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+
+### `npm run build`
+
+Builds the app for production to the `build` folder.\
+It correctly bundles React in production mode and optimizes the build for the best performance.
+
+The build is minified and the filenames include the hashes.\
+Your app is ready to be deployed!
+
+See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+
+### `npm run eject`
+
+**Note: this is a one-way operation. Once you `eject`, you can't go back!**
+
+If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+
+Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
+
+You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
+
+## Learn More
+
+You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+
+To learn React, check out the [React documentation](https://reactjs.org/).
+
+### Code Splitting
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
+
+### Analyzing the Bundle Size
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
+
+### Making a Progressive Web App
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
+
+### Advanced Configuration
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
+
+### Deployment
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
+
+### `npm run build` fails to minify
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)

--- a/README.md
+++ b/README.md
@@ -1,70 +1,21 @@
-# Getting Started with Create React App
+# NFT Marketplace
+* This is the virtual internship done for the FES bootcamp.
+* Used React + CRA, deployed in Vercel.
+* Quick link: <a target="blank" href="https://fes-virtual-internship.vercel.app/">NFT Marketplace</a>.
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+## Changelog
+**[1.4] - 2024/12/09**
+* Implemented explore items feature on explore page.
 
-## Available Scripts
+**[1.3] - 2024/12/09**
+* Implemented top sellers feature on home page.
 
-In the project directory, you can run:
+**[1.2] - 2024/12/09**
+* Implemented countdown reusable component.
+* Implemented new items feature on home page.
 
-### `npm start`
+**[1.1] - 2024/12/09**
+* Implemented hot collections feature on home page.
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+**[1.0] - 2024/12/09**
+* Started project on 12/09.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 // packages
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 // css
-import 'react-loading-skeleton/dist/skeleton.css'
+import 'react-loading-skeleton/dist/skeleton.css';
 // pages
 import Home from './pages/Home';
 import Explore from './pages/Explore';

--- a/src/components/UI/NFTItemCard.jsx
+++ b/src/components/UI/NFTItemCard.jsx
@@ -1,0 +1,75 @@
+// packages
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Skeleton from 'react-loading-skeleton';
+// components
+import Countdown from '../UI/Countdown';
+
+const NFTItemCardSkeleton = () => {
+	return (
+		<div className='nft__item'>
+			<div className='author_list_pp'>
+				<Skeleton circle />
+				<i className='fa fa-check' />
+			</div>
+			<div className='nft__item_wrap'>
+				<Skeleton count={1} />
+			</div>
+			<div className='nft__item_info'>
+				<Skeleton count={1} width='40%' height='18px' />
+				<Skeleton count={1} width='25%' height='14px' />
+				<div className='nft__item_like'>
+					<i className='fa fa-heart' />
+				</div>
+			</div>
+		</div>
+	);
+}
+
+const NFTItemCard = ({ data }) => {
+	return (
+		<div className='nft__item'>
+			<div className='author_list_pp'>
+				<Link to={`/author/${data.authorId}`} data-bs-toggle='tooltip' data-bs-placement='top' title='Creator: Monica Lucas'>
+					<img className='lazy' src={data.authorImage} alt={`User ${data.authorId}`} />
+					<i className='fa fa-check'></i>
+				</Link>
+			</div>
+			<Countdown time={data.expiryDate} />
+			<div className='nft__item_wrap'>
+				<div className='nft__item_extra'>
+					<div className='nft__item_buttons'>
+						<button>Buy Now</button>
+						<div className='nft__item_share'>
+							<h4>Share</h4>
+							<a href='' target='_blank' rel='noreferrer'>
+								<i className='fa fa-facebook fa-lg'></i>
+							</a>
+							<a href='' target='_blank' rel='noreferrer'>
+								<i className='fa fa-twitter fa-lg'></i>
+							</a>
+							<a href=''>
+								<i className='fa fa-envelope fa-lg'></i>
+							</a>
+						</div>
+					</div>
+				</div>
+				<Link to={`/item-details/${data.nftId}`}>
+					<img src={data.nftImage} className='lazy nft__item_preview' alt={`${data.title} image`} />
+				</Link>
+			</div>
+			<div className='nft__item_info'>
+				<Link to={`/item-details/${data.nftId}`}>
+					<h4>{data.title}</h4>
+				</Link>
+				<div className='nft__item_price'>{data.price} ETH</div>
+				<div className='nft__item_like'>
+					<i className='fa fa-heart'></i>
+					<span>{data.likes}</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export { NFTItemCard, NFTItemCardSkeleton };

--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -1,32 +1,15 @@
 // packages
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
-import Skeleton from 'react-loading-skeleton';
 import axios from 'axios';
 // components
-import Countdown from '../UI/Countdown';
+import { NFTItemCard, NFTItemCardSkeleton } from '../UI/NFTItemCard';
 
 const ExploreItemsSkeleton = () => {
   return (
     <>
       {new Array(8).fill(0).map((_, index) => (
         <div key={index} className='d-item col-lg-3 col-md-6 col-sm-6 col-xs-12 skeleton' style={{ display: 'block', backgroundSize: 'cover' }}>
-          <div key={index} className='nft__item'>
-            <div className='author_list_pp'>
-              <Skeleton circle />
-              <i className='fa fa-check' />
-            </div>
-            <div className='nft__item_wrap'>
-              <Skeleton count={1} />
-            </div>
-            <div className='nft__item_info'>
-              <Skeleton count={1} width='40%' height='18px' />
-              <Skeleton count={1} width='25%' height='14px' />
-              <div className='nft__item_like'>
-                <i className='fa fa-heart' />
-              </div>
-            </div>
-          </div>
+          <NFTItemCardSkeleton />
         </div>
       ))}
     </>
@@ -58,26 +41,28 @@ const ExploreItems = () => {
     }
   }
 
-  useEffect(() => {
-    const fetchItems = async () => {
-      // fetch API
-      try {
-        const resp = await axios.get('https://us-central1-nft-cloud-functions.cloudfunctions.net/explore');
-        setItems(resp.data);
-        setUiFilteredItems(resp.data);
-        setTimeout(() => {
-          setUiIsLoading(false);
-        }, 500);
-      } catch (error) {
-        console.error('Error fetching new items: ', error);
+  const fetchItems = async () => {
+    // fetch API
+    try {
+      const resp = await axios.get(`https://us-central1-nft-cloud-functions.cloudfunctions.net/explore${ui_filter !== '' ? `?filter=${ui_filter}` : ''}`);
+      setItems(resp.data);
+      //setUiFilteredItems(resp.data);
+      setTimeout(() => {
         setUiIsLoading(false);
-      }
+      }, 500);
+    } catch (error) {
+      console.error('Error fetching new items: ', error);
+      setUiIsLoading(false);
     }
+  }
+
+  useEffect(() => {    
     fetchItems();
   }, []);
 
   useEffect(() => {
-    filterItems();
+    //filterItems();
+    fetchItems();
   }, [ui_filter]);
 
   return (
@@ -90,49 +75,9 @@ const ExploreItems = () => {
           <option value='likes_high_to_low'>Most liked</option>
         </select>
       </div>
-      {!ui_isLoading && ui_filteredItems ? (<>
-        {ui_filteredItems?.slice(0, ui_numVisibleItems).map((item, index) => (<div key={index} className='d-item col-lg-3 col-md-6 col-sm-6 col-xs-12' style={{ display: 'block', backgroundSize: 'cover' }}>
-          <div className='nft__item'>
-            <div className='author_list_pp'>
-              <Link to={`/author/${item.authorId}`} data-bs-toggle='tooltip' data-bs-placement='top'>
-                <img className='lazy' src={item.authorImage} alt={`User ${item.authorId}`} />
-                <i className='fa fa-check' />
-              </Link>
-            </div>
-            <Countdown time={item.expiryDate} />
-            <div className='nft__item_wrap'>
-              <div className='nft__item_extra'>
-                <div className='nft__item_buttons'>
-                  <button>Buy Now</button>
-                  <div className='nft__item_share'>
-                    <h4>Share</h4>
-                    <a href='' target='_blank' rel='noreferrer'>
-                      <i className='fa fa-facebook fa-lg' />
-                    </a>
-                    <a href='' target='_blank' rel='noreferrer'>
-                      <i className='fa fa-twitter fa-lg' />
-                    </a>
-                    <a href=''>
-                      <i className='fa fa-envelope fa-lg' />
-                    </a>
-                  </div>
-                </div>
-              </div>
-              <Link to={`/item-details/${item.nftId}`}>
-                <img src={item.nftImage} className='lazy nft__item_preview' alt={`${item.title} image`} />
-              </Link>
-            </div>
-            <div className='nft__item_info'>
-              <Link to={`/item-details/${item.nftId}`}>
-                <h4>{item.title}</h4>
-              </Link>
-              <div className='nft__item_price'>{item.price} ETH</div>
-              <div className='nft__item_like'>
-                <i className='fa fa-heart'></i>
-                <span>{item.likes}</span>
-              </div>
-            </div>
-          </div>
+      {!ui_isLoading ? (<>
+        {_items?.slice(0, ui_numVisibleItems).map((item, index) => (<div key={index} className='d-item col-lg-3 col-md-6 col-sm-6 col-xs-12' style={{ display: 'block', backgroundSize: 'cover' }}>
+          <NFTItemCard data={item} />
         </div>))}
       </>) : <ExploreItemsSkeleton />}
       {(!ui_isLoading && ui_numVisibleItems < _items.length) && <div className='col-md-12 text-center'>

--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -1,78 +1,143 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+// packages
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Skeleton from 'react-loading-skeleton';
+import axios from 'axios';
+// components
+import Countdown from '../UI/Countdown';
 
-const ExploreItems = () => {
+const ExploreItemsSkeleton = () => {
   return (
     <>
-      <div>
-        <select id="filter-items" defaultValue="">
-          <option value="">Default</option>
-          <option value="price_low_to_high">Price, Low to High</option>
-          <option value="price_high_to_low">Price, High to Low</option>
-          <option value="likes_high_to_low">Most liked</option>
-        </select>
-      </div>
       {new Array(8).fill(0).map((_, index) => (
-        <div
-          key={index}
-          className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
-          style={{ display: "block", backgroundSize: "cover" }}
-        >
-          <div className="nft__item">
-            <div className="author_list_pp">
-              <Link
-                to="/author"
-                data-bs-toggle="tooltip"
-                data-bs-placement="top"
-              >
-                <img className="lazy" src={AuthorImage} alt="" />
-                <i className="fa fa-check"></i>
-              </Link>
+        <div key={index} className='d-item col-lg-3 col-md-6 col-sm-6 col-xs-12 skeleton' style={{ display: 'block', backgroundSize: 'cover' }}>
+          <div key={index} className='nft__item'>
+            <div className='author_list_pp'>
+              <Skeleton circle />
+              <i className='fa fa-check' />
             </div>
-            <div className="de_countdown">5h 30m 32s</div>
-
-            <div className="nft__item_wrap">
-              <div className="nft__item_extra">
-                <div className="nft__item_buttons">
-                  <button>Buy Now</button>
-                  <div className="nft__item_share">
-                    <h4>Share</h4>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-facebook fa-lg"></i>
-                    </a>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-twitter fa-lg"></i>
-                    </a>
-                    <a href="">
-                      <i className="fa fa-envelope fa-lg"></i>
-                    </a>
-                  </div>
-                </div>
-              </div>
-              <Link to="/item-details">
-                <img src={nftImage} className="lazy nft__item_preview" alt="" />
-              </Link>
+            <div className='nft__item_wrap'>
+              <Skeleton count={1} />
             </div>
-            <div className="nft__item_info">
-              <Link to="/item-details">
-                <h4>Pinky Ocean</h4>
-              </Link>
-              <div className="nft__item_price">1.74 ETH</div>
-              <div className="nft__item_like">
-                <i className="fa fa-heart"></i>
-                <span>69</span>
+            <div className='nft__item_info'>
+              <Skeleton count={1} width='40%' height='18px' />
+              <Skeleton count={1} width='25%' height='14px' />
+              <div className='nft__item_like'>
+                <i className='fa fa-heart' />
               </div>
             </div>
           </div>
         </div>
       ))}
-      <div className="col-md-12 text-center">
-        <Link to="" id="loadmore" className="btn-main lead">
-          Load more
-        </Link>
+    </>
+  );
+}
+
+const ExploreItems = () => {
+  // states
+  const [_items, setItems] = useState([]);
+  const [ui_isLoading, setUiIsLoading] = useState(true);
+  const [ui_filter, setUiFilter] = useState('');
+  const [ui_filteredItems, setUiFilteredItems] = useState('');
+  const [ui_numVisibleItems, setUiNumVisibleItems] = useState(8);
+
+  const filterItems = () => {
+    switch (ui_filter) {
+      case 'price_low_to_high':
+        setUiFilteredItems(_items.slice().sort((a, b) => a.price - b.price));
+        break;
+      case 'price_high_to_low':
+        setUiFilteredItems(_items.slice().sort((a, b) => b.price - a.price));
+        break;
+      case 'likes_high_to_low':
+        setUiFilteredItems(_items.slice().sort((a, b) => b.likes - a.likes));
+        break;
+      default:
+        setUiFilteredItems(_items);
+        break;
+    }
+  }
+
+  useEffect(() => {
+    const fetchItems = async () => {
+      // fetch API
+      try {
+        const resp = await axios.get('https://us-central1-nft-cloud-functions.cloudfunctions.net/explore');
+        setItems(resp.data);
+        setUiFilteredItems(resp.data);
+        setTimeout(() => {
+          setUiIsLoading(false);
+        }, 500);
+      } catch (error) {
+        console.error('Error fetching new items: ', error);
+        setUiIsLoading(false);
+      }
+    }
+    fetchItems();
+  }, []);
+
+  useEffect(() => {
+    filterItems();
+  }, [ui_filter]);
+
+  return (
+    <>
+      <div>
+        <select id='filter-items' defaultValue='' onChange={(e) => setUiFilter(e.target.value)}>
+          <option value=''>Default</option>
+          <option value='price_low_to_high'>Price, Low to High</option>
+          <option value='price_high_to_low'>Price, High to Low</option>
+          <option value='likes_high_to_low'>Most liked</option>
+        </select>
       </div>
+      {!ui_isLoading && ui_filteredItems ? (<>
+        {ui_filteredItems?.slice(0, ui_numVisibleItems).map((item, index) => (<div key={index} className='d-item col-lg-3 col-md-6 col-sm-6 col-xs-12' style={{ display: 'block', backgroundSize: 'cover' }}>
+          <div className='nft__item'>
+            <div className='author_list_pp'>
+              <Link to={`/author/${item.authorId}`} data-bs-toggle='tooltip' data-bs-placement='top'>
+                <img className='lazy' src={item.authorImage} alt={`User ${item.authorId}`} />
+                <i className='fa fa-check' />
+              </Link>
+            </div>
+            <Countdown time={item.expiryDate} />
+            <div className='nft__item_wrap'>
+              <div className='nft__item_extra'>
+                <div className='nft__item_buttons'>
+                  <button>Buy Now</button>
+                  <div className='nft__item_share'>
+                    <h4>Share</h4>
+                    <a href='' target='_blank' rel='noreferrer'>
+                      <i className='fa fa-facebook fa-lg' />
+                    </a>
+                    <a href='' target='_blank' rel='noreferrer'>
+                      <i className='fa fa-twitter fa-lg' />
+                    </a>
+                    <a href=''>
+                      <i className='fa fa-envelope fa-lg' />
+                    </a>
+                  </div>
+                </div>
+              </div>
+              <Link to={`/item-details/${item.nftId}`}>
+                <img src={item.nftImage} className='lazy nft__item_preview' alt={`${item.title} image`} />
+              </Link>
+            </div>
+            <div className='nft__item_info'>
+              <Link to={`/item-details/${item.nftId}`}>
+                <h4>{item.title}</h4>
+              </Link>
+              <div className='nft__item_price'>{item.price} ETH</div>
+              <div className='nft__item_like'>
+                <i className='fa fa-heart'></i>
+                <span>{item.likes}</span>
+              </div>
+            </div>
+          </div>
+        </div>))}
+      </>) : <ExploreItemsSkeleton />}
+      {(!ui_isLoading && ui_numVisibleItems < _items.length) && <div className='col-md-12 text-center'>
+        <button id='loadmore' className='btn-main lead' onClick={() => setUiNumVisibleItems((prev) => prev + 4)}>Load more</button>
+      </div>}
     </>
   );
 };

--- a/src/components/explore/HeaderExplore.jsx
+++ b/src/components/explore/HeaderExplore.jsx
@@ -1,37 +1,23 @@
-import React from "react";
+// packages
+import React from 'react';
 
 const HeaderExplore = () => {
   return (
-    <div className="col-lg-12">
-      <div className="items_filter">
-        <form
-          action="blank.php"
-          className="row form-dark"
-          id="form_quick_search"
-          method="post"
-          name="form_quick_search"
-        >
-          <div className="col text-center">
-            <input
-              className="form-control"
-              id="name_1"
-              name="name_1"
-              placeholder="search item here..."
-              type="text"
-            />{" "}
-            <a href="#" id="btn-submit">
-              <i className="fa fa-search bg-color-secondary"></i>
+    <div className='col-lg-12'>
+      <div className='items_filter'>
+        <form action='blank.php' className='row form-dark' id='form_quick_search' method='post' name='form_quick_search'>
+          <div className='col text-center'>
+            <input className='form-control' id='name_1' name='name_1' placeholder='search item here...' type='text' />{' '}
+            <a href='#' id='btn-submit'>
+              <i className='fa fa-search bg-color-secondary' />
             </a>
-            <div className="clearfix"></div>
+            <div className='clearfix' />
           </div>
         </form>
-
-        <div id="item_category" className="dropdown">
-          <a href="#" className="btn-selector">
-            All categories
-          </a>
+        <div id='item_category' className='dropdown'>
+          <a href='#' className='btn-selector'>All categories</a>
           <ul>
-            <li className="active">
+            <li className='active'>
               <span>All categories</span>
             </li>
             <li>
@@ -60,13 +46,10 @@ const HeaderExplore = () => {
             </li>
           </ul>
         </div>
-
-        <div id="buy_category" className="dropdown">
-          <a href="#" className="btn-selector">
-            Buy Now
-          </a>
+        <div id='buy_category' className='dropdown'>
+          <a href='#' className='btn-selector'>Buy Now</a>
           <ul>
-            <li className="active">
+            <li className='active'>
               <span>Buy Now</span>
             </li>
             <li>
@@ -77,13 +60,10 @@ const HeaderExplore = () => {
             </li>
           </ul>
         </div>
-
-        <div id="items_type" className="dropdown">
-          <a href="#" className="btn-selector">
-            All Items
-          </a>
+        <div id='items_type' className='dropdown'>
+          <a href='#' className='btn-selector'>All Items</a>
           <ul>
-            <li className="active">
+            <li className='active'>
               <span>All Items</span>
             </li>
             <li>

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -1,34 +1,15 @@
 // packages
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
-import Skeleton from 'react-loading-skeleton';
 import OwlCarousel from 'react-owl-carousel';
 import axios from 'axios';
 // components
-import Countdown from '../UI/Countdown';
+import { NFTItemCard, NFTItemCardSkeleton } from '../UI/NFTItemCard';
 
 const NewItemsSkeleton = () => {
   return (
     <div className='owl-carousel owl-theme skeleton'>
       <div className='owl-stage-outer'>
-        {new Array(4).fill(0).map((_, index) => (
-          <div key={index} className='nft__item'>
-            <div className='author_list_pp'>
-              <Skeleton circle />
-              <i className='fa fa-check' />
-            </div>
-            <div className='nft__item_wrap'>
-              <Skeleton count={1} />
-            </div>
-            <div className='nft__item_info'>
-              <Skeleton count={1} width='40%' height='18px' />
-              <Skeleton count={1} width='25%' height='14px' />
-              <div className='nft__item_like'>
-                <i className='fa fa-heart' />
-              </div>
-            </div>
-          </div>
-        ))}
+        {new Array(4).fill(0).map((_, index) => (<NFTItemCardSkeleton key={index} />))}
       </div>
       <div className='owl-nav'>
         <button type='button' role='presentation' className='owl-prev'><span aria-label='Previous'>‹</span></button>
@@ -79,49 +60,7 @@ const NewItems = () => {
             </div>
           </div>
           {ui_isLoading ? <NewItemsSkeleton /> : <OwlCarousel className='owl-theme' loop margin={10} nav responsive={carouselOptionsResponsive}>
-            {_items?.map((item, index) => (<React.Fragment key={index}>
-              <div className='nft__item'>
-                <div className='author_list_pp'>
-                  <Link to={`/author/${item.authorId}`} data-bs-toggle='tooltip' data-bs-placement='top' title='Creator: Monica Lucas'>
-                    <img className='lazy' src={item.authorImage} alt={`User ${item.authorId}`} />
-                    <i className='fa fa-check'></i>
-                  </Link>
-                </div>
-                <Countdown time={item.expiryDate} />
-                <div className='nft__item_wrap'>
-                  <div className='nft__item_extra'>
-                    <div className='nft__item_buttons'>
-                      <button>Buy Now</button>
-                      <div className='nft__item_share'>
-                        <h4>Share</h4>
-                        <a href='' target='_blank' rel='noreferrer'>
-                          <i className='fa fa-facebook fa-lg'></i>
-                        </a>
-                        <a href='' target='_blank' rel='noreferrer'>
-                          <i className='fa fa-twitter fa-lg'></i>
-                        </a>
-                        <a href=''>
-                          <i className='fa fa-envelope fa-lg'></i>
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                  <Link to={`/item-details/${item.nftId}`}>
-                    <img src={item.nftImage} className='lazy nft__item_preview' alt={`${item.title} image`} />
-                  </Link>
-                </div>
-                <div className='nft__item_info'>
-                  <Link to={`/item-details/${item.nftId}`}>
-                    <h4>{item.title}</h4>
-                  </Link>
-                  <div className='nft__item_price'>{item.price} ETH</div>
-                  <div className='nft__item_like'>
-                    <i className='fa fa-heart'></i>
-                    <span>{item.likes}</span>
-                  </div>
-                </div>
-              </div>
-            </React.Fragment>))}
+            {_items?.map((item, index) => (<NFTItemCard key={index} data={item} />))}
           </OwlCarousel>}
         </div>
       </div>


### PR DESCRIPTION
**Task**
The explore items feature is used on the explore page showing all the NFT items available. Users can also filter by price or likes to find the NFT they are interested in.

**Purpose**
The explore page essentially acts as a page that users can search for NFTs. Since the home page only displays hot and new NFTs, it does not encompass all available NFTs on the marketplace. As an NFT marketplace, it makes sense to have a page where users can find and explore NFTs. Allowing users the ability to filter through NFTs are also helpful.

**Action**
The API endpoint that returns explorable NFT items was fetched with a `useEffect` when the page loads. The component consists of a list of NFT items on a grid showing 8 items at first. The user can click on a "load more" button to view more NFTs, each time adding 4 items to the grid. A limit to the amount visible makes loading data faster for the user and not affect performance. The NFT item cards are also made into reusable components.

***Redo of filtering with API endpoint instead***
The first time hitting only the main endpoint was implemented. Finished watching the video and found out that the endpoint accepts query parameters that filter the data being requested, so redid the implementation with that one instead of having to use React hooks.
![image](https://github.com/user-attachments/assets/b1d171af-b1e3-4659-82d3-a64c80e1e2fe)