### PR TITLE
implemented author page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 * Quick link: <a target="blank" href="https://fes-virtual-internship.vercel.app/">NFT Marketplace</a>.
 
 ## Changelog
+**[1.5] - 2024/12/09**
+* Implemented author page.
+
 **[1.4] - 2024/12/09**
 * Implemented explore items feature on explore page.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,9 +18,7 @@ function App() {
       <Routes>
         <Route path='/' element={<Home />} />
         <Route path='/explore' element={<Explore />} />
-        <Route path='/author' element={<Author />} />
         <Route path='/author/:id' element={<Author />} />
-        <Route path='/item-details' element={<ItemDetails />} />
         <Route path='/item-details/:id' element={<ItemDetails />} />
       </Routes>
       <Footer />

--- a/src/components/UI/NFTItemCard.jsx
+++ b/src/components/UI/NFTItemCard.jsx
@@ -26,12 +26,12 @@ const NFTItemCardSkeleton = () => {
 	);
 }
 
-const NFTItemCard = ({ data }) => {
+const NFTItemCard = ({ data, authorId, authorImage }) => {
 	return (
 		<div className='nft__item'>
 			<div className='author_list_pp'>
-				<Link to={`/author/${data.authorId}`} data-bs-toggle='tooltip' data-bs-placement='top' title='Creator: Monica Lucas'>
-					<img className='lazy' src={data.authorImage} alt={`User ${data.authorId}`} />
+				<Link to={`/author/${data.authorId || authorId}`} data-bs-toggle='tooltip' data-bs-placement='top' title='Creator: Monica Lucas'>
+					<img className='lazy' src={data.authorImage || authorImage} alt={`User ${data.authorId || authorId}`} />
 					<i className='fa fa-check'></i>
 				</Link>
 			</div>

--- a/src/components/author/AuthorItems.jsx
+++ b/src/components/author/AuthorItems.jsx
@@ -1,61 +1,33 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+// packages
+import React from 'react';
+// components
+import { NFTItemCard, NFTItemCardSkeleton } from '../UI/NFTItemCard';
 
-const AuthorItems = () => {
+const AuthorItemsSkeleton = () => {
   return (
-    <div className="de_tab_content">
-      <div className="tab-1">
-        <div className="row">
-          {new Array(8).fill(0).map((_, index) => (
-            <div className="col-lg-3 col-md-6 col-sm-6 col-xs-12" key={index}>
-              <div className="nft__item">
-                <div className="author_list_pp">
-                  <Link to="">
-                    <img className="lazy" src={AuthorImage} alt="" />
-                    <i className="fa fa-check"></i>
-                  </Link>
-                </div>
-                <div className="nft__item_wrap">
-                  <div className="nft__item_extra">
-                    <div className="nft__item_buttons">
-                      <button>Buy Now</button>
-                      <div className="nft__item_share">
-                        <h4>Share</h4>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-facebook fa-lg"></i>
-                        </a>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-twitter fa-lg"></i>
-                        </a>
-                        <a href="">
-                          <i className="fa fa-envelope fa-lg"></i>
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                  <Link to="/item-details">
-                    <img
-                      src={nftImage}
-                      className="lazy nft__item_preview"
-                      alt=""
-                    />
-                  </Link>
-                </div>
-                <div className="nft__item_info">
-                  <Link to="/item-details">
-                    <h4>Pinky Ocean</h4>
-                  </Link>
-                  <div className="nft__item_price">2.52 ETH</div>
-                  <div className="nft__item_like">
-                    <i className="fa fa-heart"></i>
-                    <span>97</span>
-                  </div>
-                </div>
+    <>
+      {new Array(8).fill(0).map((_, index) => (
+        <div className='col-lg-3 col-md-6 col-sm-6 col-xs-12' key={index}>
+          <NFTItemCardSkeleton />
+        </div>
+      ))}
+    </>
+  );
+}
+
+const AuthorItems = ({ authorId, authorImage, items, isLoading }) => {
+
+  return (
+    <div className='de_tab_content'>
+      <div className='tab-1'>
+        <div className='row'>
+          {isLoading ? <AuthorItemsSkeleton /> : (<>
+            {items?.map((item, index) => (
+              <div className='col-lg-3 col-md-6 col-sm-6 col-xs-12' key={index}>
+                <NFTItemCard data={item} authorId={authorId} authorImage={authorImage} />
               </div>
-            </div>
-          ))}
+            ))}
+          </>)}
         </div>
       </div>
     </div>

--- a/src/css/styles/global.css
+++ b/src/css/styles/global.css
@@ -25,6 +25,13 @@
 .skeleton.author_list { display:block; }
 .skeleton.author_list .author_list_info { display:flex; flex-direction:column; gap:8px; }
 .skeleton.author_list .author_list_info span { line-height:1; }
+
+/** author **/
+.skeleton .d_profile, .skeleton .de_tab { width:100%; }
+.skeleton .profile_avatar .react-loading-skeleton { width:150px; height:150px; }
+.skeleton .profile_name { display:flex; flex-direction:column; justify-content:center; gap:16px; }
+.skeleton .profile_name > span { width:100%; display:block; }
+.skeleton .profile_name .react-loading-skeleton { width:100%; }
 /********** END SKELETONS **********/
 
 /****** SCREEN SIZES ******/

--- a/src/pages/Author.jsx
+++ b/src/pages/Author.jsx
@@ -1,63 +1,134 @@
-import React from "react";
-import AuthorBanner from "../images/author_banner.jpg";
-import AuthorItems from "../components/author/AuthorItems";
-import { Link } from "react-router-dom";
-import AuthorImage from "../images/author_thumbnail.jpg";
+// packages
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import Skeleton from 'react-loading-skeleton';
+import axios from 'axios';
+// components
+import AuthorItems from '../components/author/AuthorItems';
+// assets
+import AuthorBanner from '../images/author_banner.jpg';
+
+const AuthorSkeleton = ({ isLoading }) => {
+  return (
+    <div className='row'>
+      <div className='col-md-12 skeleton'>
+        <div className='d_profile de-flex'>
+          <div className='de-flex-col'>
+            <div className='profile_avatar'>
+              <Skeleton circle />
+              <i className='fa fa-check' />
+              <div className='profile_name'>
+                <Skeleton count={1} width='200px' height='28px' />
+                <Skeleton count={1} width='50%' height='16px' />
+                <Skeleton count={1} width='200px' height='16px' />
+              </div>
+            </div>
+          </div>
+          <div className='profile_follow de-flex'>
+            <div className='de-flex-col'>
+              <Skeleton count={1} width='150px' height='42px' />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className='col-md-12 skeleton'>
+        <div className='de_tab tab_simple'>
+          <AuthorItems isLoading={isLoading} />
+        </div>
+      </div>
+    </div>
+  );
+}
 
 const Author = () => {
+  // hooks
+  const { id } = useParams();
+  // states
+  const [_author, setAuthor] = useState({});
+  const [ui_isLoading, setUiIsLoading] = useState(true);
+  const [ui_isFollowing, setUiIsFollowing] = useState(false);
+  const [ui_isCopiedText, setUiIsCopiedText] = useState('Copy');
+
+  const handleFollowing = () => {
+    let newState = !ui_isFollowing;
+    if (newState) {
+      setAuthor((prev) => ({ ...prev, followers: prev.followers + 1 }));
+    } else {
+      setAuthor((prev) => ({ ...prev, followers: prev.followers - 1 }));
+    }
+    setUiIsFollowing((prev) => !prev);
+  }
+
+  const handleCopied = () => {
+    navigator.clipboard.writeText(_author.address);
+    setUiIsCopiedText('Copied!');
+  }
+  
+  useEffect(() => {
+    const fetchAuthor = async () => {
+      // fetch API
+      try {
+        const resp = await axios.get(`https://us-central1-nft-cloud-functions.cloudfunctions.net/authors?author=${id}`);
+        setAuthor(resp.data);
+        setTimeout(() => {
+          setUiIsLoading(false);
+        }, 500);
+      } catch (error) {
+        console.error('Error fetching author: ', error);
+        setUiIsLoading(false);
+      }
+    }
+    fetchAuthor();
+  }, []);
+
+  useEffect(() => {
+    // change back to allowing user to copy
+    if(ui_isCopiedText === 'Copied!') {
+      setTimeout(() => {
+        setUiIsCopiedText('Copy');
+      }, 2000);
+    }
+  }, [ui_isCopiedText]);
+
   return (
-    <div id="wrapper">
-      <div className="no-bottom no-top" id="content">
-        <div id="top"></div>
-
-        <section
-          id="profile_banner"
-          aria-label="section"
-          className="text-light"
-          data-bgimage="url(images/author_banner.jpg) top"
-          style={{ background: `url(${AuthorBanner}) top` }}
-        ></section>
-
-        <section aria-label="section">
-          <div className="container">
-            <div className="row">
-              <div className="col-md-12">
-                <div className="d_profile de-flex">
-                  <div className="de-flex-col">
-                    <div className="profile_avatar">
-                      <img src={AuthorImage} alt="" />
-
-                      <i className="fa fa-check"></i>
-                      <div className="profile_name">
-                        <h4>
-                          Monica Lucas
-                          <span className="profile_username">@monicaaaa</span>
-                          <span id="wallet" className="profile_wallet">
-                            UDHUHWudhwd78wdt7edb32uidbwyuidhg7wUHIFUHWewiqdj87dy7
-                          </span>
-                          <button id="btn_copy" title="Copy Text">
-                            Copy
-                          </button>
-                        </h4>
+    <div id='wrapper'>
+      <div className='no-bottom no-top' id='content'>
+        <div id='top'></div>
+        <section id='profile_banner' aria-label='section' className='text-light' data-bgimage='url(images/author_banner.jpg) top' style={{ background: `url(${AuthorBanner}) top` }} />
+        <section aria-label='section'>
+          <div className='container'>
+            <div className='row'>
+              {ui_isLoading ? <AuthorSkeleton isLoading={ui_isLoading} /> : (<div className='row'>
+                <div className='col-md-12'>
+                  <div className='d_profile de-flex'>
+                    <div className='de-flex-col'>
+                      <div className='profile_avatar'>
+                        <img src={_author.authorImage} alt='' />
+                        <i className='fa fa-check'></i>
+                        <div className='profile_name'>
+                          <h4>
+                            {_author.authorName}
+                            <span className='profile_username'>@{_author.tag}</span>
+                            <span id='wallet' className='profile_wallet'>{_author.address}</span>
+                            <button id='btn_copy' title='Copy Text' onClick={handleCopied}>{ui_isCopiedText}</button>
+                          </h4>
+                        </div>
+                      </div>
+                    </div>
+                    <div className='profile_follow de-flex'>
+                      <div className='de-flex-col'>
+                        <div className='profile_follower'>{_author.followers} followers</div>
+                        <button className='btn-main' onClick={handleFollowing}>{ui_isFollowing ? 'Unfollow' : 'Follow'}</button>
                       </div>
                     </div>
                   </div>
-                  <div className="profile_follow de-flex">
-                    <div className="de-flex-col">
-                      <div className="profile_follower">573 followers</div>
-                      <Link to="#" className="btn-main">
-                        Follow
-                      </Link>
-                    </div>
+                </div>
+                <div className='col-md-12'>
+                  <div className='de_tab tab_simple'>
+                    <AuthorItems authorId={_author.authorId} authorImage={_author.authorImage} items={_author.nftCollection} />
                   </div>
                 </div>
-              </div>
-
-              <div className="col-md-12">
-                <div className="de_tab tab_simple">
-                  <AuthorItems />
-                </div>
-              </div>
+              </div>)}
             </div>
           </div>
         </section>


### PR DESCRIPTION
**Task**
The author page is takes users to their or other people's profile pages. The authors of the NFT marketplace are users who create or share NFT items. Each profile page lists their image, name, address, number of followers, and NFT collections.

**Purpose**
The author page is the page that shows information about each author. This gives a profile template displaying important and also basic information about the author. This can also make users find more NFTs that come from the same author.

**Action**
The API endpoint that returns a specific author's information on the NFT marketplace was fetched with a `useEffect` when the page loads. The author page has a loading state and a populated state. Furthermore, the `AuthorItems` component basically utilizes the reusable component `NFTItemCard`, which was also used previously on the home page's "New Items" section and the explore page. A button to unfollow and follow the specific author is also implemented, updating the number (not changing the database directly from API). A simple copy function for the author's NFT address was added as well.

***Some changes to the reusable component***
Since the previous use consisted of the author's information from the API endpoint, it wasn't necessary to pass such props. However, the API endpoint used this time doesn't return author information because it is stored as an object array inside of the author's `nftCollection` field anyway, so it is necessary to pass in the current author's ID and image to the reusable component. Depending on the usage, if the `data`'s two fields exist, then the `authorId` and `authorImage` prop won't be used (as they would be `null` if not coming from the author page).
![image](https://github.com/user-attachments/assets/62803781-16c0-4024-a86b-f1fafa6803fd)